### PR TITLE
Update 10config.yaml

### DIFF
--- a/prometheus/10config.yaml
+++ b/prometheus/10config.yaml
@@ -10,7 +10,7 @@ data:
     global:
       scrape_interval:     15s
       evaluation_interval: 15s
-      scrape_timeout:      20s
+      scrape_timeout:      15s
 
     rule_files:
       - '/prometheus/rules/*.rules'


### PR DESCRIPTION
fix prometheus boot error
 err="error loading config from \"/etc/prometheus/prometheus.yaml\": couldn't load configuration (--config.file=\"/etc/prometheus/prometheus.yaml\"): parsing YAML file /etc/prometheus/prometheus.yaml: global scrape timeout greater than scrape interval"